### PR TITLE
Added support for serde's 'rename_all' attribute

### DIFF
--- a/src/to_typescript/enums.rs
+++ b/src/to_typescript/enums.rs
@@ -35,7 +35,8 @@ impl super::ToTypescript for syn::ItemEnum {
         state.types.push('\n');
 
         let comments = utils::get_comments(self.clone().attrs);
-        let casing = utils::get_attribute_arg("serde", "renameAll", &self.attrs);
+        let casing = utils::get_attribute_arg("serde", "rename_all", &self.attrs)
+            .or(utils::get_attribute_arg("serde", "renameAll", &self.attrs));
         let casing = to_enum_case(casing);
 
         let is_single = !self.variants.iter().any(|x| !x.fields.is_empty());

--- a/test/enum/rust.rs
+++ b/test/enum/rust.rs
@@ -49,7 +49,7 @@ enum Animal {
     Cat,
 }
 #[tsync]
-#[serde(renameAll = "snake_case")]
+#[serde(rename_all = "snake_case")]
 enum AnimalTwo {
     DogLongExtra = 2,
     Cat,


### PR DESCRIPTION
Serde 1.0 throws an error when attempting to use the `renameAll` attribute per tests:

> error: unknown serde container attribute `renameAll`

This adds support for the `rename_all` attribute according to https://serde.rs/container-attrs.html

I originally changed just the tag, removing support for `renameAll`, but I added a separate check in case the other tag is used somewhere I'm not aware of.