### PR TITLE
feat: implement support for serde flatten

### DIFF
--- a/src/to_typescript/structs.rs
+++ b/src/to_typescript/structs.rs
@@ -12,11 +12,26 @@ impl super::ToTypescript for syn::ItemStruct {
         let comments = utils::get_comments(self.clone().attrs);
         state.write_comments(&comments, 0);
 
-        state.types.push_str(&format!(
-            "{export}interface {interface_name}{generics} {{\n",
-            interface_name = self.ident,
-            generics = utils::extract_struct_generics(self.generics.clone())
-        ));
+        let intersections = get_intersections(&self.fields);
+
+        match intersections {
+            Some(intersections) => {
+                state.types.push_str(&format!(
+                    "{export}type {struct_name}{generics} = {intersections} & {{\n",
+                    export = export,
+                    struct_name = self.ident,
+                    generics = utils::extract_struct_generics(self.generics.clone()),
+                    intersections = intersections
+                ));
+            }
+            None => {
+                state.types.push_str(&format!(
+                    "{export}interface {interface_name}{generics} {{\n",
+                    interface_name = self.ident,
+                    generics = utils::extract_struct_generics(self.generics.clone())
+                ));
+            }
+        }
 
         process_fields(self.fields, state, 2, casing);
         state.types.push('}');
@@ -33,6 +48,12 @@ pub fn process_fields(
     let space = utils::build_indentation(indentation_amount);
     let case = case.into();
     for field in fields {
+        // Check if the field has the serde flatten attribute, if so, skip it
+        let has_flatten_attr = utils::get_attribute_arg("serde", "flatten", &field.attrs).is_some();
+        if has_flatten_attr {
+            continue;
+        }
+
         let comments = utils::get_comments(field.attrs);
 
         state.write_comments(&comments, 2);
@@ -54,4 +75,22 @@ pub fn process_fields(
             field_type = field_type.ts_type
         ));
     }
+}
+
+fn get_intersections(fields: &syn::Fields) -> Option<String> {
+    let mut types = Vec::new();
+
+    for field in fields {
+        let has_flatten_attr = utils::get_attribute_arg("serde", "flatten", &field.attrs).is_some();
+        let field_type = convert_type(&field.ty);
+        if has_flatten_attr {
+            types.push(field_type.ts_type);
+        }
+    }
+
+    if types.is_empty() {
+        return None;
+    }
+
+    Some(types.join(" & "))
 }

--- a/test/struct/rust.rs
+++ b/test/struct/rust.rs
@@ -11,6 +11,8 @@ struct Book {
     /// Reviews of the book
     /// by users.
     user_reviews: Option<Vec<String>>,
+    #[serde(flatten)]
+    book_type: BookType,
 }
 
 #[tsync]
@@ -43,7 +45,6 @@ struct PaginationResult<T> {
     total_items: number,
 }
 
-
 #[tsync]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -51,4 +52,31 @@ struct PaginationResult<T> {
 struct PaginationResultCamel<T> {
     items: Vec<T>,
     total_items: number,
+}
+
+#[tsync]
+#[derive(Serialize)]
+/// Struct with flattened field.
+struct Author {
+    name: String,
+    #[serde(flatten)]
+    name: AuthorName,
+}
+
+#[tsync]
+#[derive(Serialize)]
+struct AuthorName {
+    alias: Option<String>,
+    first_name: String,
+    last_name: String,
+}
+
+#[tsync]
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum BookType {
+    #[serde(rename = "fiction")]
+    Fiction { genre: String },
+    #[serde(rename = "non-fiction")]
+    NonFiction { subject: String },
 }

--- a/test/struct/typescript.d.ts
+++ b/test/struct/typescript.d.ts
@@ -1,7 +1,7 @@
 /* This file is generated and managed by tsync */
 
 /** Doc comments are preserved too! */
-interface Book {
+type Book = BookType & {
   /** Name of the book. */
   name: string;
   /** Chapters of the book. */
@@ -47,3 +47,27 @@ interface PaginationResultCamel<T> {
   items: Array<T>;
   totalItems: number;
 }
+
+/** Struct with flattened field. */
+type Author = AuthorName & {
+  name: string;
+}
+
+interface AuthorName {
+  alias?: string;
+  first_name: string;
+  last_name: string;
+}
+
+type BookType =
+  | BookType__Fiction
+  | BookType__NonFiction;
+
+type BookType__Fiction = {
+  type: "Fiction";
+  genre: string;
+};
+type BookType__NonFiction = {
+  type: "NonFiction";
+  subject: string;
+};

--- a/test/struct/typescript.ts
+++ b/test/struct/typescript.ts
@@ -1,7 +1,7 @@
 /* This file is generated and managed by tsync */
 
 /** Doc comments are preserved too! */
-export interface Book {
+export type Book = BookType & {
   /** Name of the book. */
   name: string;
   /** Chapters of the book. */
@@ -47,3 +47,27 @@ export interface PaginationResultCamel<T> {
   items: Array<T>;
   totalItems: number;
 }
+
+/** Struct with flattened field. */
+export type Author = AuthorName & {
+  name: string;
+}
+
+export interface AuthorName {
+  alias?: string;
+  first_name: string;
+  last_name: string;
+}
+
+export type BookType =
+  | BookType__Fiction
+  | BookType__NonFiction;
+
+type BookType__Fiction = {
+  type: "Fiction";
+  genre: string;
+};
+type BookType__NonFiction = {
+  type: "NonFiction";
+  subject: string;
+};


### PR DESCRIPTION
Addresses #48 

Will convert these Rust types:
```rust
#[tsync]
#[derive(Serialize)]
/// Struct with flattened field.
struct Author {
    name: String,
    #[serde(flatten)]
    name: AuthorName,
}

#[tsync]
#[derive(Serialize)]
struct AuthorName {
    alias: Option<String>,
    first_name: String,
    last_name: String,
}
```
To these TypeScript types:
```ts
/** Struct with flattened field. */
export type Author = AuthorName & {
  name: string;
}

export interface AuthorName {
  alias?: string;
  first_name: string;
  last_name: string;
}
```

It also supports enums, so the following Rust types:
```rust
/// Doc comments are preserved too!
#[tsync]
struct Book {
    /// Name of the book.
    name: String,
    /// Chapters of the book.
    chapters: Vec<Chapter>,
    /// Reviews of the book
    /// by users.
    user_reviews: Option<Vec<String>>,
    #[serde(flatten)]
    book_type: BookType,
}

#[tsync]
#[derive(Serialize)]
#[serde(tag = "type")]
enum BookType {
    Fiction { genre: String },
    NonFiction { subject: String },
}
```
Will generate these TypeScript types:
```ts
/** Doc comments are preserved too! */
export type Book = BookType & {
  /** Name of the book. */
  name: string;
  /** Chapters of the book. */
  chapters: Array<Chapter>;
  /**
   * Reviews of the book
   * by users.
   */
  user_reviews?: Array<string>;
}

export type BookType =
  | BookType__Fiction
  | BookType__NonFiction;

type BookType__Fiction = {
  type: "Fiction";
  genre: string;
};
type BookType__NonFiction = {
  type: "NonFiction";
  subject: string;
};
```