### PR TITLE
feat: raw identifiers

### DIFF
--- a/src/to_typescript/consts.rs
+++ b/src/to_typescript/consts.rs
@@ -1,4 +1,5 @@
 use syn::__private::ToTokens;
+use syn::ext::IdentExt;
 
 use crate::{utils, BuildState};
 
@@ -16,7 +17,7 @@ impl super::ToTypescript for syn::ItemConst {
         // however doesn't enforce that the json! macro contains no variables.
         // if your lucky you might have also tsynced them but otherwise you will get a typescript error.
 
-        let name = self.ident.to_string();
+        let name = self.ident.unraw().to_string();
         let body = match self.expr.as_ref() {
             syn::Expr::Lit(literal) => {
                 // convert it directly to a string to put in TS.

--- a/src/to_typescript/enums.rs
+++ b/src/to_typescript/enums.rs
@@ -1,6 +1,7 @@
 use crate::{typescript::convert_type, utils, BuildState};
 use convert_case::{Case, Casing};
 use syn::__private::ToTokens;
+use syn::ext::IdentExt;
 
 /// Conversion of Rust Enum to Typescript using external tagging as per https://serde.rs/enum-representations.html
 /// however conversion will adhere to the `serde` `tag` such that enums are intenrally tagged
@@ -59,9 +60,9 @@ fn add_enum(
 
     for variant in exported_struct.variants {
         let field_name = if let Some(casing) = casing {
-            variant.ident.to_string().to_case(casing)
+            variant.ident.unraw().to_string().to_case(casing)
         } else {
-            variant.ident.to_string()
+            variant.ident.unraw().to_string()
         };
         state.types.push_str(&format!(" | \"{}\"", field_name));
     }
@@ -141,9 +142,9 @@ fn add_numeric_enum(
     for variant in exported_struct.variants {
         state.types.push('\n');
         let field_name = if let Some(casing) = casing {
-            variant.ident.to_string().to_case(casing)
+            variant.ident.unraw().to_string().to_case(casing)
         } else {
-            variant.ident.to_string()
+            variant.ident.unraw().to_string()
         };
         if let Some((_, disc)) = variant.discriminant {
             if let Ok(new_disc) = disc.to_token_stream().to_string().parse::<i32>() {
@@ -237,7 +238,7 @@ fn add_internally_tagged_enum(
                 state.types.push_str(&format!(
                     "  | {interface_name}__{variant_name}{generics}",
                     interface_name = exported_struct.ident,
-                    variant_name = variant.ident,
+                    variant_name = variant.ident.unraw(),
                     generics = utils::format_generics(&variant_generics)
                 ))
             }
@@ -262,7 +263,7 @@ fn add_internally_tagged_enum(
                 state.types.push_str(&format!(
                     "type {interface_name}__{variant_name}{generics} = ",
                     interface_name = exported_struct.ident,
-                    variant_name = variant.ident,
+                    variant_name = variant.ident.unraw(),
                 ));
                 // add discriminant
                 state.types.push_str(&format!(
@@ -281,13 +282,13 @@ fn add_internally_tagged_enum(
                 state.types.push_str(&format!(
                     "type {interface_name}__{variant_name}{generics} = ",
                     interface_name = exported_struct.ident,
-                    variant_name = variant.ident,
+                    variant_name = variant.ident.unraw(),
                 ));
 
                 let field_name = if let Some(casing) = casing {
-                    variant.ident.to_string().to_case(casing)
+                    variant.ident.unraw().to_string().to_case(casing)
                 } else {
-                    variant.ident.to_string()
+                    variant.ident.unraw().to_string()
                 };
                 // add discriminant
                 state.types.push_str(&format!(
@@ -322,13 +323,13 @@ fn add_internally_tagged_enum(
                 state.types.push_str(&format!(
                     "type {interface_name}__{variant_name}{generics} = ",
                     interface_name = exported_struct.ident,
-                    variant_name = variant.ident,
+                    variant_name = variant.ident.unraw(),
                 ));
 
                 let field_name = if let Some(casing) = casing {
-                    variant.ident.to_string().to_case(casing)
+                    variant.ident.unraw().to_string().to_case(casing)
                 } else {
-                    variant.ident.to_string()
+                    variant.ident.unraw().to_string()
                 };
                 // add discriminant
                 state.types.push_str(&format!(
@@ -365,9 +366,9 @@ fn add_externally_tagged_enum(
         let comments = utils::get_comments(variant.attrs);
         state.write_comments(&comments, 2);
         let field_name = if let Some(casing) = casing {
-            variant.ident.to_string().to_case(casing)
+            variant.ident.unraw().to_string().to_case(casing)
         } else {
-            variant.ident.to_string()
+            variant.ident.unraw().to_string()
         };
 
         if let syn::Fields::Unnamed(fields) = &variant.fields {

--- a/src/to_typescript/structs.rs
+++ b/src/to_typescript/structs.rs
@@ -1,6 +1,7 @@
 use crate::typescript::convert_type;
 use crate::{utils, BuildState};
 use convert_case::{Case, Casing};
+use syn::ext::IdentExt;
 
 impl super::ToTypescript for syn::ItemStruct {
     fn convert_to_ts(self, state: &mut BuildState, config: &crate::BuildSettings) {
@@ -107,10 +108,10 @@ pub fn process_fields(
         let field_name = if let Some(name_case) = case {
             field
                 .ident
-                .map(|id| id.to_string().to_case(name_case))
+                .map(|id| id.unraw().to_string().to_case(name_case))
                 .unwrap()
         } else {
-            field.ident.map(|i| i.to_string()).unwrap()
+            field.ident.map(|i| i.unraw().to_string()).unwrap()
         };
 
         let field_type = convert_type(&field.ty);

--- a/src/to_typescript/type_item.rs
+++ b/src/to_typescript/type_item.rs
@@ -1,10 +1,11 @@
 use crate::BuildState;
+use syn::ext::IdentExt;
 
 impl super::ToTypescript for syn::ItemType {
     fn convert_to_ts(self, state: &mut BuildState, config: &crate::BuildSettings) {
         let export = if config.uses_type_interface { "" } else { "export " };
         state.types.push('\n');
-        let name = self.ident.to_string();
+        let name = self.ident.unraw().to_string();
         let ty = crate::typescript::convert_type(&self.ty);
         let comments = crate::utils::get_comments(self.attrs);
         state.write_comments(&comments, 0);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -271,3 +271,4 @@ pub(crate) fn parse_serde_case(val: impl Into<Option<String>>) -> Option<convert
             .map(|(_, rule)| *rule)
     })
 }
+

--- a/test/raw_identifiers/rust.rs
+++ b/test/raw_identifiers/rust.rs
@@ -1,0 +1,53 @@
+#[tsync]
+struct RawIdentifierStruct {
+    r#type: String,
+    r#async: i32,
+    r#loop: bool,
+    normal_field: String,
+}
+
+#[tsync]
+#[serde(rename_all = "camelCase")]
+struct RawIdentifierCamelCase {
+    r#type: String,
+    r#const: u32,
+    regular_field: String,
+}
+
+#[tsync]
+enum RawIdentifierEnum {
+    r#type,
+    r#async,
+    r#match,
+    NormalVariant,
+}
+
+#[tsync]
+#[serde(rename_all = "UPPERCASE")]
+enum RawIdentifierEnumUppercase {
+    r#type,
+    r#const,
+    NormalVariant,
+}
+
+#[tsync]
+#[repr(u8)]
+enum RawIdentifierNumericEnum {
+    r#type = 1,
+    r#async = 2,
+    NormalVariant = 3,
+}
+
+#[tsync]
+#[serde(tag = "kind")]
+enum RawIdentifierTaggedEnum {
+    r#type { value: String },
+    r#async { count: u32 },
+    NormalVariant { data: bool },
+}
+
+#[tsync]
+type r#type = String;
+
+#[tsync]
+type r#async = Vec<i32>;

--- a/test/raw_identifiers/tsync.sh
+++ b/test/raw_identifiers/tsync.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+cd $SCRIPT_DIR
+
+cargo run -- -i rust.rs -o typescript.d.ts
+cargo run -- -i rust.rs -o typescript.ts

--- a/test/raw_identifiers/typescript.d.ts
+++ b/test/raw_identifiers/typescript.d.ts
@@ -1,0 +1,45 @@
+/* This file is generated and managed by tsync */
+
+interface RawIdentifierStruct {
+  type: string;
+  async: number;
+  loop: boolean;
+  normal_field: string;
+}
+
+interface RawIdentifierCamelCase {
+  type: string;
+  const: number;
+  regularField: string;
+}
+
+type RawIdentifierEnum =
+  | "type" | "async" | "match" | "NormalVariant";
+
+type RawIdentifierEnumUppercase =
+  | "TYPE" | "CONST" | "NORMAL VARIANT";
+
+type RawIdentifierNumericEnum =
+  | "type" | "async" | "NormalVariant";
+
+type RawIdentifierTaggedEnum =
+  | RawIdentifierTaggedEnum__type
+  | RawIdentifierTaggedEnum__async
+  | RawIdentifierTaggedEnum__NormalVariant;
+
+type RawIdentifierTaggedEnum__type = {
+  kind: "type";
+  value: string;
+};
+type RawIdentifierTaggedEnum__async = {
+  kind: "async";
+  count: number;
+};
+type RawIdentifierTaggedEnum__NormalVariant = {
+  kind: "NormalVariant";
+  data: boolean;
+};
+
+type type = string
+
+type async = Array<number>

--- a/test/raw_identifiers/typescript.ts
+++ b/test/raw_identifiers/typescript.ts
@@ -1,0 +1,45 @@
+/* This file is generated and managed by tsync */
+
+export interface RawIdentifierStruct {
+  type: string;
+  async: number;
+  loop: boolean;
+  normal_field: string;
+}
+
+export interface RawIdentifierCamelCase {
+  type: string;
+  const: number;
+  regularField: string;
+}
+
+export type RawIdentifierEnum =
+  | "type" | "async" | "match" | "NormalVariant";
+
+export type RawIdentifierEnumUppercase =
+  | "TYPE" | "CONST" | "NORMAL VARIANT";
+
+export type RawIdentifierNumericEnum =
+  | "type" | "async" | "NormalVariant";
+
+export type RawIdentifierTaggedEnum =
+  | RawIdentifierTaggedEnum__type
+  | RawIdentifierTaggedEnum__async
+  | RawIdentifierTaggedEnum__NormalVariant;
+
+type RawIdentifierTaggedEnum__type = {
+  kind: "type";
+  value: string;
+};
+type RawIdentifierTaggedEnum__async = {
+  kind: "async";
+  count: number;
+};
+type RawIdentifierTaggedEnum__NormalVariant = {
+  kind: "NormalVariant";
+  data: boolean;
+};
+
+export type type = string
+
+export type async = Array<number>

--- a/test/test_all.sh
+++ b/test/test_all.sh
@@ -17,3 +17,4 @@ cd $SCRIPT_DIR
 ./issue-43/tsync.sh
 ./issue-55/tsync.sh
 ./issue-58/tsync.sh
+./raw_identifiers/tsync.sh


### PR DESCRIPTION
I was running into an issue where a struct using a raw identifier like

```rust
 #[tsync]
 struct RawIdentifierStruct {
     r#type: String,
 }
```

would keep the `r#type` resulting in invalid TypeScript output, e.g.

```ts
export interface RawIdentifierStruct {
  r#type: string;
}

```

With this change,


```ts
export interface RawIdentifierStruct {
  type: string;
}
```