### PR TITLE
Add flag to print to stdout #57

### DIFF
--- a/bin/main.rs
+++ b/bin/main.rs
@@ -70,8 +70,8 @@ fn main() {
         let content = tsync::generate_typescript_defs_inner(
             args.input,
             uses_type_interface,
-            args.enable_const_enums,
             args.debug,
+            args.enable_const_enums,
         );
 
         println!("{}", content.types)
@@ -79,8 +79,8 @@ fn main() {
         tsync::generate_typescript_defs(
             args.input,
             args.output,
-            args.enable_const_enums,
             args.debug,
+            args.enable_const_enums,
         );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,8 +203,8 @@ fn process_dir_entry<P: AsRef<Path>>(path: P, state: &mut BuildState, config: &B
 pub fn generate_typescript_defs_inner(
     input: Vec<PathBuf>,
     uses_type_interface: bool,
-    enable_const_enums: bool,
     debug: bool,
+    enable_const_enums: bool,
 ) -> BuildState {
     DEBUG.set(debug);
     let config = BuildSettings {
@@ -234,8 +234,8 @@ pub fn generate_typescript_defs_inner(
 pub fn generate_typescript_defs(
     input: Vec<PathBuf>,
     output: PathBuf,
-    enable_const_enums: bool,
     debug: bool,
+    enable_const_enums: bool,
 ) {
     DEBUG.set(debug);
 
@@ -245,7 +245,7 @@ pub fn generate_typescript_defs(
         .unwrap_or(true);
 
     let state =
-        generate_typescript_defs_inner(input, uses_type_interface, enable_const_enums, debug);
+        generate_typescript_defs_inner(input, uses_type_interface, debug, enable_const_enums);
 
     if debug {
         println!("======================================");


### PR DESCRIPTION
This resolves #57 by adding a function `tsync::generate_typescript_defs_inner` that returns `BuildState`. I also added the commandline flag `--stdout` that prints the content to stdout, not to a file. However you still need to specify an output file, that will not be written to, a full filename is not required, just the extention with the leading period.

All the tests pass, and the signature of generate_typescript_defs remained unchanged as not to break compatability with earlier versions.